### PR TITLE
Pin Typescript version to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "electron": "^1.0.1",
     "electron-packager": "^8.0.0",
     "excalibur": "^0.8.0-alpha.1254",
-    "typescript": "^2.1.4",
+    "typescript": "~2.1.4",
     "xo": "^0.16.0"
   },
   "xo": {


### PR DESCRIPTION
Otherwise an "uncaught reference error" about exports not being defined is thrown. See https://github.com/electron-userland/electron-forge-templates/issues/19#issuecomment-282398626 for the proposed solution for now.